### PR TITLE
Implement mixed-mode text color artifacts

### DIFF
--- a/Apple-II.sv
+++ b/Apple-II.sv
@@ -208,7 +208,7 @@ parameter CONF_STR = {
 	"S1,HDV;",
 	"-;",
 	"OCD,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
-	"O23,Display,Color,B&W,Green,Amber;",
+	"OJL,Display,Color 1,Color 2,B&W,Green,Amber;",
 	"O9B,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;", 
 	"OEF,Scale,Normal,V-Integer,Narrower HV-Integer,Wider HV-Integer;",
 	"OG,Pixel Clock,Double,Normal;",
@@ -318,6 +318,33 @@ end
 
 wire led;
 wire hbl,vbl;
+
+reg [1:0] screen_mode;
+reg       text_color;
+
+always @(status[21:19]) case (status[21:19])
+	3'b000: begin
+		screen_mode = 2'b00;
+		text_color = 0;
+	end
+	3'b001: begin
+		screen_mode = 2'b00;
+		text_color = 1;
+	end
+	3'b010: begin
+		screen_mode = 2'b01;
+		text_color = 0;
+	end
+	3'b011: begin
+		screen_mode = 2'b10;
+		text_color = 0;
+	end
+	3'b100: begin
+		screen_mode = 2'b11;
+		text_color = 0;
+	end
+endcase // always @ (status[21:19])
+
 apple2_top apple2_top
 (
 	.CLK_14M(clk_sys),
@@ -334,7 +361,8 @@ apple2_top apple2_top
 	.r(R),
 	.g(G),
 	.b(B),
-	.SCREEN_MODE(status[3:2]),
+	.SCREEN_MODE(screen_mode),
+	.TEXT_COLOR(text_color),
 
 	.AUDIO_L(audio_l),
 	.AUDIO_R(audio_r),

--- a/rtl/apple2.vhd
+++ b/rtl/apple2.vhd
@@ -33,6 +33,7 @@ entity apple2 is
     ram_we         : out std_logic;              -- RAM write enable
     VIDEO          : out std_logic;
     COLOR_LINE     : out std_logic;
+    TEXT_MODE      : buffer std_logic;
     HBL            : out std_logic;
     VBL            : buffer std_logic;
     K              : in unsigned(7 downto 0);    -- Keyboard data
@@ -78,7 +79,6 @@ architecture rtl of apple2 is
   
   -- Soft switches
   signal soft_switches : std_logic_vector(7 downto 0) := "00000000";
-  signal TEXT_MODE : std_logic;
   signal MIXED_MODE : std_logic;
   signal PAGE2 : std_logic;
   signal HIRES_MODE : std_logic;

--- a/rtl/apple2_top.vhd
+++ b/rtl/apple2_top.vhd
@@ -46,6 +46,8 @@ port (
 	g              : out std_logic_vector(7 downto 0);
 	b              : out std_logic_vector(7 downto 0);
 	SCREEN_MODE    : in  std_logic_vector(1 downto 0); -- 00: Color, 01: B&W, 10:Green, 11: Amber
+	TEXT_COLOR     : in  std_logic; -- 1 = color processing for
+	                                -- text lines in mixed modes
 
 	PS2_Key        : in  std_logic_vector(10 downto 0);
 	joy            : in  std_logic_vector(5 downto 0);
@@ -93,6 +95,7 @@ architecture arch of apple2_top is
   signal VIDEO, HBL, VBL : std_logic;
   signal COLOR_LINE : std_logic;
   signal COLOR_LINE_CONTROL : std_logic;
+  signal TEXT_MODE : std_logic;
   signal GAMEPORT : std_logic_vector(7 downto 0);
 
   signal K : unsigned(7 downto 0);
@@ -179,8 +182,8 @@ begin
     end if;
   end process;
 
-  COLOR_LINE_CONTROL <= COLOR_LINE and not (SCREEN_MODE(1) or SCREEN_MODE(0));  -- Color or B&W mode
-  
+  COLOR_LINE_CONTROL <= (COLOR_LINE or (TEXT_COLOR and not TEXT_MODE)) and not (SCREEN_MODE(1) or SCREEN_MODE(0));  -- Color or B&W mode
+
   -- Simulate power up on cold reset to go to the disk boot routine
   ram_we   <= we_ram when reset_cold = '0' else '1';
   ram_addr <= std_logic_vector(a_ram) when reset_cold = '0' else std_logic_vector(to_unsigned(1012,ram_addr'length)); -- $3F4
@@ -210,6 +213,7 @@ begin
     ram_we         => we_ram,
     VIDEO          => VIDEO,
     COLOR_LINE     => COLOR_LINE,
+    TEXT_MODE      => TEXT_MODE,
     HBL            => HBL,
     VBL            => VBL,
     K              => K,


### PR DESCRIPTION
On original Apple II hardware, the text portion of mixed display modes
is processed as being in color. The core's logic was written to
optimize readability by making this text monochrome, but the color
processing produces a distinctive blurring and colorization effect
expected by experienced Apple II users.

Add a new OSD "Display" option to allow optionally reproducing this
effect, renaming the current default "Color" to "Color 1" and
introducing a "Color 2" mode that reproduces the effect.