### PR TITLE
F9 shortcut and better palette for IIc PAL

### DIFF
--- a/Apple-II.sv
+++ b/Apple-II.sv
@@ -217,8 +217,8 @@ parameter CONF_STR = {
 	"-;",
 	"S1,HDV;",
 	"-;",
-	"OJL,Display,Color 1,Color 2,B&W,Green,Amber;",
-	"OOP,Color palette,//e,IIgs,AppleWin,apple2fpga;",
+	"OJK,Display,Color,B&W,Green,Amber;",
+	"OOP,Color palette,NTSC //e,IIgs,AppleWin,PAL //c;",
 	"-;",
 	"P1,System & BIOS;",
 	"P1-;",
@@ -234,6 +234,8 @@ parameter CONF_STR = {
 	"P2O78,Stereo mix,none,25%,50%,100%;",
 	"P2-;",	
 	"P2OG,Pixel Clock,Double,Normal;",
+	"P2OL,Lo-Res Text,Clean,Composite;",
+	"P2-;",	
 	"P2O9B,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;", 
 	"P2OCD,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
 	"P2OEF,Scale,Normal,V-Integer,Narrower HV-Integer,Wider HV-Integer;",
@@ -306,6 +308,8 @@ hps_io #(.CONF_STR(CONF_STR), .VDNUM(3)) hps_io
 
 	.buttons(buttons),
 	.status(status),
+	.status_in({status[31:26],palette_req,status[23:21],screen_mode_req,status[18:0]}),
+	.status_set(video_toggle), //|palette_toggle),
 	.forced_scandoubler(forced_scandoubler),
 	.gamma_bus(gamma_bus),
 
@@ -363,31 +367,38 @@ end
 wire led;
 wire hbl,vbl;
 
-reg [1:0] screen_mode;
 reg       text_color;
+reg       video_toggle;
+reg       palette_toggle;
+wire [1:0] screen_mode;
+wire [1:0] palette_mode;
+reg [1:0] screen_mode_req;
+reg [1:0] palette_req;
 
-always @(status[21:19]) case (status[21:19])
-	3'b001: begin
-		screen_mode = 2'b00;
-		text_color = 1;
-	end
-	3'b010: begin
-		screen_mode = 2'b01;
-		text_color = 0;
-	end
-	3'b011: begin
-		screen_mode = 2'b10;
-		text_color = 0;
-	end
-	3'b100: begin
-		screen_mode = 2'b11;
-		text_color = 0;
-	end
-	default: begin
-		screen_mode = 2'b00;
-		text_color = 0;
-	end
-endcase // always @ (status[21:19])
+assign screen_mode = status[20:19];
+assign palette_mode = status[25:24];
+
+always @(posedge clk_sys) begin
+
+	reg old_toggle = 0;
+	old_toggle <= video_toggle;
+	
+	// display change request from keyboard
+	if (video_toggle != old_toggle) begin
+		screen_mode_req <= screen_mode + 1'b1;
+		//palette_req <= palette_mode;
+	end /*else begin
+		if (palette_toggle & !video_toggle) begin
+			palette_req <= palette_mode + 1'b1;
+		end;
+	end */
+end
+
+always @(posedge clk_sys) begin	
+	// flag to enable Lo-Res text artifacting, only applicable in screen mode 2'b00
+	text_color <= (~status[20] & ~status[19] & status[21]);
+end  
+
 
 apple2_top apple2_top
 (
@@ -408,8 +419,10 @@ apple2_top apple2_top
 	.r(R),
 	.g(G),
 	.b(B),
-	.SCREEN_MODE(screen_mode),
-	.TEXT_COLOR(text_color),
+	.video_switch(video_toggle),
+	.palette_switch(palette_toggle),
+	.SCREEN_MODE( status[20:19] ),
+	.TEXT_COLOR( text_color ),
 	.COLOR_PALETTE(status[25:24]),
 	.PALMODE(status[22]),
 	.ROMSWITCH(~status[23]),

--- a/README.md
+++ b/README.md
@@ -18,12 +18,17 @@ NOTE: only .nib will persist saves to disk
 * joystick support
 * scanlines
 * color, amber, green and black&white monitor
+* selection of color palette (NTSC //e, Apple IIgs, AppleWin,PAL //c) 
 * language card in slot 0
 * prodos compatible clock card in slot 1
 * Super Serial Card in slot 2
 * 64K base + 64K auxilary RAM with 80 column and double hi-res support (256KB total with Saturn 128K)
 * Saturn 128k RAM expansion in slot 5 (get the utility disks from here: http://apple2online.com/?page_id=3447 , under "Saturn RAMSoft")
 * Mockingboard model A (two AY-3-8913 chips for six audio channels) in slot 4
+
+## Keyboard shortcuts
+
+* F9 - cycle through display monitor modes (color, b&w, green, amber)
 
 ## Disk format notes
 

--- a/rtl/apple2_top.vhd
+++ b/rtl/apple2_top.vhd
@@ -58,7 +58,10 @@ port (
 	SCREEN_MODE    : in  std_logic_vector(1 downto 0); -- 00: Color, 01: B&W, 10:Green, 11: Amber
 	TEXT_COLOR     : in  std_logic; -- 1 = color processing for
 	                                -- text lines in mixed modes
-	COLOR_PALETTE  :  in std_logic_vector(1 downto 0); -- 00: Original, 01: //gs, 02: //e, 03: //e alternative
+	
+	video_switch   : out std_logic;
+	palette_switch : out std_logic;
+	COLOR_PALETTE  :  in std_logic_vector(1 downto 0); -- 00: Original (//e NTSC), 01: //gs, 02: AppleWin, 03: //c PAL
 	
     PALMODE        : in  std_logic := '0';       -- PAL/NTSC selection
     ROMSWITCH      : in std_logic;
@@ -69,9 +72,7 @@ port (
 
 	-- mocking board
 	mb_enabled 		: in std_logic;
-
-
-
+	
 	-- disk control
 	TRACK1         : out unsigned( 5 downto 0); -- Current track (0-34)
 	TRACK1_ADDR    : out unsigned(12 downto 0);
@@ -363,7 +364,9 @@ begin
     akd      => akd,
     open_apple => open_apple,
     closed_apple => closed_apple,
-    soft_reset => soft_reset
+    soft_reset => soft_reset,
+    video_toggle => video_switch,
+	palette_toggle => palette_switch
     );
 
 	 

--- a/rtl/keyboard.vhd
+++ b/rtl/keyboard.vhd
@@ -23,10 +23,12 @@ entity keyboard is
     reset    : in std_logic;
     akd      : buffer std_logic;        -- Any key down
     K        : out unsigned(7 downto 0); -- Latched, decoded keyboard data
-    open_apple:out std_logic;
-    closed_apple:out std_logic;
-    soft_reset:out std_logic := '0'
-    );
+    open_apple:    out std_logic;
+    closed_apple:  out std_logic;
+    soft_reset:    out std_logic := '0';
+  	video_toggle:  out std_logic := '0';	  -- signal to control change of video modes
+    palette_toggle:out std_logic := '0'	  -- signal to control change of paleetes
+	);
 end keyboard;
 
 architecture rtl of keyboard is
@@ -50,7 +52,9 @@ architecture rtl of keyboard is
   constant WINDOWS          : unsigned(7 downto 0) := X"1F";
   constant ALT              : unsigned(7 downto 0) := X"11";
   constant F2               : unsigned(7 downto 0) := X"06";
-
+  constant F8               : unsigned(7 downto 0) := X"0A";
+  constant F9               : unsigned(7 downto 0) := X"01";
+	
   type states is (IDLE,
                   HAVE_CODE,
                   DECODE,
@@ -97,6 +101,8 @@ begin
       --open_apple<='0';
       --closed_apple<='0';
 		soft_reset<='0';
+		video_toggle<='0';
+		palette_toggle<='0';
     elsif rising_edge(CLK_14M) then
      if state = HAVE_CODE then
         if code = LEFT_SHIFT or code = RIGHT_SHIFT then
@@ -110,6 +116,10 @@ begin
         elsif code = F2 then
 		    soft_reset <= '1';
           --reset_key <= '1';
+	    elsif code = F8 then
+			palette_toggle <= '1';
+		elsif code = F9 then
+			video_toggle <= '1';
         end if;
       elsif state = KEY_UP then
         if code = LEFT_SHIFT or code = RIGHT_SHIFT then
@@ -123,6 +133,10 @@ begin
         elsif code = F2 then
           --reset_key <= '0';
 			 soft_reset <= '0';
+		elsif code = F8 then
+			palette_toggle <= '0';
+		elsif code = F9 then
+			video_toggle <= '0';
         end if;
       end if;
     end if;


### PR DESCRIPTION
* F9: cycle monitor modes (Color, B&W, Green, Amber)
* Added PAL IIc color palette (for real PAL monitors using composite)